### PR TITLE
Modified virtualenv command to explicitly create a virtual environmen…

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,7 +23,7 @@ Start by getting the source::
 You need to create a virtual environment for Python libraries. Skip the first instruction if you already have virtualenv installed::
 
     $ pip install virtualenv                       # installs virtualenv, skip if already have it
-    $ virtualenv venv                              # create a virtual env in the folder `venv`
+    $ virtualenv -p python2.7 venv                 # create a virtual env in the folder `venv`
     $ source venv/bin/activate                     # activate the virtual env
     $ bin/peep.py install -r requirements/dev.txt  # installs dependencies
 


### PR DESCRIPTION
…t using python 2.7.

Encountered errors when I executed
virtualenv venv
It defaulted to python3 virtualenv, while bedrock requires python2.7
http://dudepare.github.io/Setting-Up-Bedrock-Mozilla/
